### PR TITLE
Fix ordering installation,

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -444,6 +444,7 @@ class elasticsearch (
 
   if $elasticsearch::bool_install_prerequisites {
     class { 'elasticsearch::prerequisites':
+      require => Class['elasticsearch::install'],
     }
   }
 


### PR DESCRIPTION
 while using the class 'elasticsearch' an error occurs when the installation start for the first time, the ``elasticsearch::prerequisites`` try to copy files into non existant folder created by the ``elasticsearch::install`` class. This PR set the correct ordering for the folder creation.